### PR TITLE
Add the user prop to the donation tile

### DIFF
--- a/custom-donation-stream/custom-donation-stream.js
+++ b/custom-donation-stream/custom-donation-stream.js
@@ -74,6 +74,7 @@
 							campaign={global.campaign}
 							showAsLoading={showAsLoading || isLoading}
 							detail="basic"
+							user={scope.user}
 						/>
 					);
 				}}


### PR DESCRIPTION
Currently this example will crash as the prop `user` is undefined, and the donation tile will try and access `user.firstName`.

I've just added the missing prop, tested this on a site that was using a version of this component and it fixed their issue.