### PR TITLE
Add lead form template

### DIFF
--- a/lead-form/lead-form.js
+++ b/lead-form/lead-form.js
@@ -1,0 +1,91 @@
+(RaiselyComponents, React) => {
+	const { useState } = React;
+	const { api, Form } = RaiselyComponents;
+	const { htmr } = RaiselyComponents.Common;
+
+	const generateModifiedFields = (fields) => {
+		const newFields = [...fields.map((f) => ({ ...f }))];
+		newFields.push({
+			type: "custom",
+			id: "recaptcha",
+			render: () => <div id="recaptcha"></div>,
+		});
+		return newFields;
+	};
+
+	const siteKey = "6LdiCUIUAAAAAMuF1TD8VkdBgTlrklGyJbNgJCdn";
+	let recaptcha = [false, false]; // [ready, loaded]
+
+	return (props) => {
+		const [success, setSuccess] = useState(false);
+		const { successMessage, successRedirect, tags } = props.getValues();
+
+		const captchaInterval = setInterval(() => {
+			if (recaptcha[0] && !recaptcha[1]) {
+				recaptcha[1] = true;
+				window.grecaptcha.render("recaptcha", {
+					sitekey: siteKey,
+					size: "invisible",
+					callback: onSubmit,
+				});
+				clearInterval(captchaInterval);
+			}
+		}, 100);
+
+		const cache = {};
+
+		window.loadRecaptcha = () => {
+			recaptcha[0] = true;
+		};
+		if (window.grecaptcha && window.grecaptcha.render) {
+			recaptcha[0] = true;
+		}
+
+		const onValidate = async (data, options) => {
+			cache.data = data;
+			cache.options = options;
+			window.grecaptcha.execute();
+		};
+
+		const onSubmit = async (recaptcha) => {
+			const { data, options } = cache;
+			try {
+				const userRes = await api.users.upsert({
+					recaptcha,
+					data: {
+						...data,
+						tags: tags ? tags.map((t) => t.uuid) : [],
+					},
+				});
+
+				const res = userRes.body().data();
+				if (successRedirect) props.actions.redirect(successRedirect);
+				if (successMessage) {
+					setSuccess(true);
+				}
+			} catch (e) {
+				options.setSubmitting(false);
+				props.actions.addErrorMessage(e);
+			}
+		};
+
+		return (
+			<div className={`lead-form`}>
+				{success ? (
+					htmr(successMessage || "<p>Thank you!</p>")
+				) : (
+					<div>
+						<Form
+							global={props.global}
+							unlocked
+							fields={generateModifiedFields(
+								props.global.customFields.user
+							)}
+							action={onValidate}
+						/>
+					</div>
+				)}
+			</div>
+		);
+	};
+};

--- a/lead-form/lead-form.json
+++ b/lead-form/lead-form.json
@@ -1,0 +1,24 @@
+{
+	"fields": {
+		"version": {
+			"type": "number",
+			"label": "Current Version of Component",
+			"value": 1
+		},
+		"tags": {
+			"type": "tags",
+			"label": "Tags to add",
+			"additional": { "recordType": "user" }
+		},
+		"successMessage": {
+			"type": "textarea",
+			"label": "Success Message",
+			"value": "Thank you for entering your details."
+		},
+		"successRedirect": {
+			"type": "text",
+			"label": "Success Redirect",
+			"value": ""
+		}
+	}
+}

--- a/lead-form/lead-form.md
+++ b/lead-form/lead-form.md
@@ -1,0 +1,7 @@
+# Lead Form
+
+This component adds a lead capture form to your Raisely campaign, protected by ReCaptcha.
+
+The form can be used for newsletter signups, lead acquisition, basic event registration forms etc. Entries go into your Raisely CRM, with a tag applied.
+
+> **Note: You need to contact Raisely support to use this component as we will need to verify your domain with ReCaptcha.**


### PR DESCRIPTION
This is an example component for a lead form on Raisely, using our blind `/users/upsert` API to add user information directly into Raisely CRM.